### PR TITLE
Order by date desc tenders and winners in mail #212

### DIFF
--- a/app/management/commands/deadline_notifications.py
+++ b/app/management/commands/deadline_notifications.py
@@ -12,7 +12,7 @@ class Command(BaseCommand, BaseParamsUI):
     help = 'Send deadline notifications to all users if there are tenders with 1, 3 or 7 days left'
 
     def handle(self, *args, **options):
-        tenders = Tender.objects.filter(favourite=True, winner=None)
+        tenders = Tender.objects.filter(favourite=True, winner=None).order_by('deadline')
 
         days_list = sorted(settings.DEADLINE_NOTIFICATIONS)
 

--- a/app/management/commands/notify.py
+++ b/app/management/commands/notify.py
@@ -28,8 +28,8 @@ class Command(BaseCommand, BaseParamsUI):
 
     def handle(self, *args, **options):
         digest = options['digest']
-        tenders = Tender.objects.filter(notified=False)
-        awards = Winner.objects.filter(notified=False)
+        tenders = Tender.objects.filter(notified=False).order_by('-published')
+        awards = Winner.objects.filter(notified=False).order_by('-award_date')
         if (len(tenders) > 0) or (len(awards) > 0):
             send_email(tenders, awards, digest)
 

--- a/app/management/commands/notify_favorites.py
+++ b/app/management/commands/notify_favorites.py
@@ -10,5 +10,5 @@ class Command(BaseNotifyCommand, BaseParamsUI):
         return 'Favorite'
 
     def get_tenders(self):
-        tenders = Tender.objects.filter(favourite=True)
+        tenders = Tender.objects.filter(favourite=True).order_by('-published')
         return tenders

--- a/app/management/commands/notify_keywords.py
+++ b/app/management/commands/notify_keywords.py
@@ -10,5 +10,5 @@ class Command(BaseNotifyCommand, BaseParamsUI):
         return 'Keyword'
 
     def get_tenders(self):
-        tenders = Tender.objects.filter(has_keywords=True)
+        tenders = Tender.objects.filter(has_keywords=True).order_by('-published')
         return tenders

--- a/app/templates/contract_awards_list.html
+++ b/app/templates/contract_awards_list.html
@@ -35,7 +35,7 @@
           <td>{{ winner.tender.organization }}</td>
           <td>{{ winner.award_date | date:'d M Y' }}</td>
           <td>{{ winner.vendor }}</td>
-          <td>{{ winner.value }}</td>
+          <td>{{ winner.value| floatformat:'0' }}</td>
           <td>{{ winner.currency }}</td>
         </tr>
       {% endfor %}

--- a/app/templates/detail_award.html
+++ b/app/templates/detail_award.html
@@ -16,6 +16,10 @@
       </thead>
       <tbody>
       <tr>
+        <td>Link to tender</td>
+        <td><a href="{{ winner.tender.url }}" target="_blank">{{ winner.tender.url }}</a></td>
+      </tr>
+      <tr>
         <td>Award Date</td>
         <td>{{ winner.award_date | date:'d M Y' }}</td>
       </tr>
@@ -25,7 +29,7 @@
       </tr>
       <tr>
         <td>Value</td>
-        <td>{{ winner.value }}</td>
+        <td>{{ winner.value | floatformat:'0' }}</td>
       </tr>
       <tr>
         <td>Currency</td>

--- a/app/templates/search_results.html
+++ b/app/templates/search_results.html
@@ -29,7 +29,7 @@
         <p class="list-group-item list-group-item-action search-element">
           <a class="search-tender-title" href="{% url 'contract_awards_detail_view' award.id %}" >{{ award.vendor }}</a>
           <br>
-          <a class="truncate-search">{{ award.currency }}, {{ award.value }}, {{ award.tender.title }}</a>
+          <a class="truncate-search">{{ award.currency }}, {{ award.value | floatformat:'0' }}, {{ award.tender.title }}</a>
         </p>
       {% endfor %}
     </div>

--- a/app/tests/test_mail.py
+++ b/app/tests/test_mail.py
@@ -1,6 +1,10 @@
+from datetime import datetime, timedelta
+
+from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core import mail, management
 from django.template.loader import render_to_string
+from django.utils import timezone
 
 from app.factories import TenderFactory, NotificationFactory, KeywordFactory
 from app.management.commands.notify import build_email
@@ -17,18 +21,24 @@ class SendMailTest(BaseTestCase):
             title="test_title1",
             url="https://www.ungm.org/Public/Notice/94909",
             favourite=True,
+            published=datetime.now(timezone.utc) - timedelta(days=2),
+            deadline=datetime.now(timezone.utc) + timedelta(days=3) - timedelta(hours=1),
         )
 
         self.tender2 = TenderFactory(
             reference="2019/FLCHI/FLCHI/102665",
             title="test_title2 python",
             url="https://www.ungm.org/Public/Notice/94920",
+            published=datetime.now(timezone.utc) - timedelta(days=3),
+            deadline=datetime.now(timezone.utc) + timedelta(days=7) - timedelta(hours=1),
         )
 
         self.tender3 = TenderFactory(
             reference="RFP 56956",
             title="test_title3",
             url="https://www.ungm.org/Public/Notice/92850",
+            published=datetime.now(timezone.utc) - timedelta(days=1),
+            deadline=datetime.now(timezone.utc) + timedelta(days=1) - timedelta(hours=1),
         )
 
         self.notified_user1 = NotificationFactory()
@@ -63,6 +73,31 @@ class SendMailTest(BaseTestCase):
         self.assertEqual(self.tender2.organization in alt_body, True)
         self.assertEqual(self.tender3.organization in alt_body, True)
 
+    def test_notify(self):
+        management.call_command("notify")
+        self.assertEqual(len(mail.outbox), 3)
+
+        mail1 = mail.outbox[0].alternatives[0][0]
+        mail2 = mail.outbox[1].alternatives[0][0]
+        mail3 = mail.outbox[2].alternatives[0][0]
+
+        self.assertEqual(self.tender3.title in mail1, True)
+        self.assertEqual(self.tender1.title in mail2, True)
+        self.assertEqual(self.tender2.title in mail3, True)
+
+    def test_notify_digest(self):
+        management.call_command("notify", digest=True)
+        self.assertEqual(len(mail.outbox), 1)
+
+        alt_body = mail.outbox[0].alternatives[0][0]
+        soup = BeautifulSoup(alt_body, "html.parser")
+
+        tender_list = soup.find("ol", {"class": "tender-list"}).find_all("a")
+        self.assertEqual(len(tender_list), 3)
+        self.assertEqual(tender_list[0]["href"], self.tender3.url)
+        self.assertEqual(tender_list[1]["href"], self.tender1.url)
+        self.assertEqual(tender_list[2]["href"], self.tender2.url)
+
     def test_mailing_favorites(self):
         original_tender1_organization = self.tender1.organization
         management.call_command("notify_favorites")
@@ -90,6 +125,29 @@ class SendMailTest(BaseTestCase):
         self.assertEqual(self.tender1.organization in message, True)
         self.assertEqual(self.tender3.organization in message, False)
 
+    def test_mailing_favorites_digest(self):
+        self.tender2 = Tender.objects.get(reference=self.tender2.reference)
+        self.tender2.organization = "CHANGE2"
+        self.tender2.favourite = True
+        self.tender2.save()
+
+        self.tender3 = Tender.objects.get(reference=self.tender3.reference)
+        self.tender3.organization = "CHANGE3"
+        self.tender3.favourite = True
+        self.tender3.save()
+
+        management.call_command("notify_favorites", digest=True)
+        self.assertEqual(len(mail.outbox), 1)
+
+        alt_body = mail.outbox[0].alternatives[0][0]
+        soup = BeautifulSoup(alt_body, "html.parser")
+
+        tender_list = soup.find("ol", {"class": "tender-list"}).find_all("a")
+        self.assertEqual(len(tender_list), 3)
+        self.assertEqual(tender_list[0]["href"], self.tender3.url)
+        self.assertEqual(tender_list[1]["href"], self.tender1.url)
+        self.assertEqual(tender_list[2]["href"], self.tender2.url)
+
     def test_mailing_keywords(self):
         management.call_command("notify_keywords")
         self.assertEqual(len(mail.outbox), 1)
@@ -110,3 +168,48 @@ class SendMailTest(BaseTestCase):
         self.assertEqual("Keyword tender(s) update" in message, True)
         self.assertEqual(self.tender2.organization in message, False)
         self.assertEqual(self.tender3.organization in message, False)
+
+    def test_mailing_keywords_digest(self):
+        self.tender1 = Tender.objects.get(reference=self.tender1.reference)
+        self.tender1.title = "test_title1 python"
+        self.tender1.save()
+
+        self.tender2 = Tender.objects.get(reference=self.tender2.reference)
+        self.tender2.title = "test_title2 changed python"
+        self.tender2.save()
+
+        self.tender3 = Tender.objects.get(reference=self.tender3.reference)
+        self.tender3.title = "test_title3 python"
+        self.tender3.save()
+
+        management.call_command("notify_keywords", digest=True)
+        self.assertEqual(len(mail.outbox), 1)
+
+        alt_body = mail.outbox[0].alternatives[0][0]
+        soup = BeautifulSoup(alt_body, "html.parser")
+
+        tender_list = soup.find("ol", {"class": "tender-list"}).find_all("a")
+        self.assertEqual(len(tender_list), 3)
+        self.assertEqual(tender_list[0]["href"], self.tender3.url)
+        self.assertEqual(tender_list[1]["href"], self.tender1.url)
+        self.assertEqual(tender_list[2]["href"], self.tender2.url)
+
+    def test_deadline_notification(self):
+        self.tender2 = Tender.objects.get(reference=self.tender2.reference)
+        self.tender2.favourite = True
+        self.tender2.save()
+
+        self.tender3 = Tender.objects.get(reference=self.tender3.reference)
+        self.tender3.favourite = True
+        self.tender3.save()
+
+        management.call_command("deadline_notifications")
+        self.assertEqual(len(mail.outbox), 3)
+
+        mail1 = mail.outbox[0].alternatives[0][0]
+        mail2 = mail.outbox[1].alternatives[0][0]
+        mail3 = mail.outbox[2].alternatives[0][0]
+
+        self.assertEqual(self.tender3.url in mail1, True)
+        self.assertEqual(self.tender1.url in mail2, True)
+        self.assertEqual(self.tender2.url in mail3, True)

--- a/app/views.py
+++ b/app/views.py
@@ -47,7 +47,10 @@ class HomepageView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         today = date.today()
-        tomorrow = today + timedelta(days=1)
+
+        now = datetime.now(timezone.utc)
+        deadline_gte = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        deadline_lt = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
 
         context["ungm_tenders"] = Tender.objects.filter(source="UNGM").count()
         context["ted_tenders"] = Tender.objects.filter(source="TED").count()
@@ -68,10 +71,10 @@ class HomepageView(TemplateView):
             published__exact=today, source="TED"
         ).count()
         context["ungm_deadline_today"] = Tender.objects.filter(
-            deadline__gte=today, deadline__lt=tomorrow, source="UNGM"
+            deadline__gte=deadline_gte, deadline__lt=deadline_lt, source="UNGM"
         ).count()
         context["ted_deadline_today"] = Tender.objects.filter(
-            deadline__gte=today, deadline__lt=tomorrow, source="TED"
+            deadline__gte=deadline_gte, deadline__lt=deadline_lt, source="TED"
         ).count()
 
         return context

--- a/scratch/settings.py
+++ b/scratch/settings.py
@@ -155,7 +155,7 @@ instance_dir = os.path.abspath(os.path.dirname(__file__))
 FILES_DIR = os.path.join(instance_dir, 'files')
 
 # DEADLINE
-DEADLINE_NOTIFICATIONS = env('DEADLINE_NOTIFICATIONS', (1, 2, 7))
+DEADLINE_NOTIFICATIONS = env('DEADLINE_NOTIFICATIONS', (1, 3, 7))
 
 # TED
 TED_DOC_TYPES = env('TED_DOC_TYPES', [])

--- a/scratch/settings.py
+++ b/scratch/settings.py
@@ -175,6 +175,8 @@ USE_L10N = True
 
 USE_TZ = True
 
+USE_THOUSAND_SEPARATOR = True
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 


### PR DESCRIPTION
### Fixes:
- Order by date desc tenders and winners in mail #212
- Link to tender is missing for contract awards #208
- Number formatting in contract awards #207
- Tender has a naive datetime for deadline #202