### PR TITLE
Fix setup for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,7 @@ Create the stack and start it:
 
 ## Testing
 
-Install the test requirements
-
-    pip install -r requirements-dev.txt
-
-Run the test suite
+You can run the test suite as follows:
 
     python manage.py test --settings=scratch.test_settings
 

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -2,8 +2,10 @@ version: '2'
 
 services:
   web:
-    image: scratch
-    build: .
+    build:
+      context: .
+      args:
+        REQFILE: requirements-dev.txt
     volumes:
       - .:/var/local/scratch
     entrypoint: ["/usr/bin/tail", "-f", "/dev/null"]
@@ -26,6 +28,14 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.6.1
     container_name: scratch.elasticsearch_test
     environment:
+      - discovery.type=single-node
+      - http.port=9200
+      - http.cors.enabled=true
+      - http.cors.allow-origin=http://localhost:1358,http://127.0.0.1:1358
+      - http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
+      - http.cors.allow-credentials=true
+      - bootstrap.system_call_filter=false
+      - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:
@@ -35,7 +45,7 @@ services:
     volumes:
       - esdata_test:/usr/share/elasticsearch/data
     ports:
-      - 9201:9201
+      - 9201:9200
 
   dejavu:
     image: appbaseio/dejavu

--- a/docker/app.env.example
+++ b/docker/app.env.example
@@ -21,7 +21,7 @@ EMAIL_PORT=25
 EMAIL_HOST_USER=
 EMAIL_HOST_PASSWORD=
 EMAIL_SENDER=scratch@eaudeweb.ro
-DELETE_EXPIRED_DAYS=
+DELETE_EXPIRED_DAYS=5
 ELASTICSEARCH_HOST=elasticsearch
 ELASTICSEARCH_AUTH=user:password
 # Add the following variables if you plan on running the tests


### PR DESCRIPTION
- Remove need for manually installing dev requirements
- Fix elasticsearch_test service to work on macOS 12 (Monterey)