### PR TITLE
Fix "TenderDocument's 'document' attribute has no file associated with it" bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ web client at http://localhost:1358/?appname=%2A&url=http://localhost:9200/
 - Bootstrap checks failed: When starting the Elasticsearch container, this error may ocurr. The following command should fix it.
 
         sudo sysctl -w vm.max_map_count=262144
+- TenderDocument objects have no actual file associated: Due to a failed request to download a tender document, 
+TenderDocument objects without an actual document may be created and saved in the db. After the cause of the request 
+failure is resolved, you can fix the incomplete objects already saved in the db by running the following command, 
+which will download the documents for the instances where they are missing:
+
+   ```commandline
+  python manage.py add_documents
+   ```
 
 ## Management Commands
 

--- a/app/management/commands/add_documents.py
+++ b/app/management/commands/add_documents.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+
+from app.models import TenderDocument
+from app.parsers.ungm import UNGMWorker
+
+
+class Command(BaseCommand):
+    help = "Adds documents where missing for each TenderDocument object"
+
+    def handle(self, *args, **options):
+
+        tender_docs = TenderDocument.objects.all()
+
+        for doc in tender_docs:
+            if not doc.document:
+                self.stdout.write(self.style.SUCCESS("Downloading document %s" % doc.name))
+                UNGMWorker.download_document(doc)
+

--- a/app/parsers/ungm.py
+++ b/app/parsers/ungm.py
@@ -241,7 +241,10 @@ class UNGMWorker:
     @staticmethod
     def download_document(tender_doc):
         with TemporaryFile() as content:
-            response = requests.get(tender_doc.download_url, stream=True)
+            headers = {
+                'User-Agent': 'Mozilla/5.0'
+            }
+            response = requests.get(tender_doc.download_url, headers=headers, stream=True)
             if response.status_code == 200:
                 for chunk in response.iter_content(chunk_size=4096):
                     content.write(chunk)


### PR DESCRIPTION
Closes: https://github.com/eaudeweb/scratch/issues/268