### PR TITLE
Corrected the formation of the URL

### DIFF
--- a/app/templates/mails/deadline_alert.html
+++ b/app/templates/mails/deadline_alert.html
@@ -4,7 +4,7 @@
 {% endblock %}
 {% block content %}
   <h2>
-    <a href="{{ domain }}/tenders/{{ tender.id }}">{{ tender.title }}</a>
+    <a href="{{ domain }}/tenders/{{ tender.id|urlencode }}">{{ tender.title }}</a>
   </h2>
   {% if tender.deadline %}
     <p class="deadline">

--- a/app/templates/mails/new_awards.html
+++ b/app/templates/mails/new_awards.html
@@ -11,7 +11,7 @@
       {% for award in awards %}
         <li>
           <h2>
-            <a href="{{ domain }}/awards/{{ award.id }}">{{ award.tender.title }} </a>
+            <a href="{{ domain }}/awards/{{ award.id|urlencode }}">{{ award.tender.title }} </a>
           </h2>
           <p class="published clip">
             {% if award.award_date %}

--- a/app/templates/mails/new_tenders.html
+++ b/app/templates/mails/new_tenders.html
@@ -12,7 +12,7 @@
         {% for tender in tenders %}
           <li>
             <h2>
-              <a href="{{ domain }}/tenders/{{ tender.id }}">{{ tender.title }} </a>
+              <a href="{{ domain }}/tenders/{{ tender.id|urlencode }}">{{ tender.title }} </a>
             </h2>
             <p class="published clip">
               {% if tender.published %}

--- a/app/templates/mails/tender_update.html
+++ b/app/templates/mails/tender_update.html
@@ -7,7 +7,7 @@
     {% for tender in tenders %}
       <li>
         <h2>
-          <a href="{{ domain }}/tenders/{{ tender.id }}">{{ tender.title }}</a>
+          <a href="{{ domain }}/tenders/{{ tender.id|urlencode }}">{{ tender.title }}</a>
         </h2>
         <p class="published clip">
           {% if tender.published %}


### PR DESCRIPTION
I have made a change to the URL formation for the emails pages in order to resolve an issue where the URLs were being generated with a comma instead of a period. This was caused by the way the 'tender.id' variable was being passed into the URL pattern. I have now implemented the use of the urlencode filter to properly encode the tender.id variable before it is passed into the URL pattern.